### PR TITLE
interreg domain logo

### DIFF
--- a/journey/config.yml
+++ b/journey/config.yml
@@ -17,7 +17,7 @@ brandByDomain:
     brandNavbar: ''
     brandNavbarLogo: merano
 
-  mentor.opendatahub.bz.it:
+  journey.opendatahub.bz.it:
     branding: Mentor
     title: Mentor
     brandNavbar: ''


### PR DESCRIPTION
updated interreg logo for domain journey.opendatahub.bz.it
- require a rebuild of journey