### PR TITLE
Update OTP2 documentation, add elevation data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC0-1.0
 
 # Mentor
 
-This project contains a Docker images for stable [OpenTripPlanner](http://opentripplanner.org) releases and tools to auto download Openstreetmap data related to a certain gtfs file.
+This project contains automation for building an [OpenTripPlanner](http://opentripplanner.org) container image that includes OSM and GTFS data for South Tyrol.
 
 [![REUSE Compliance](https://github.com/noi-techpark/odh-mentor-otp/actions/workflows/reuse.yml/badge.svg)](https://github.com/noi-techpark/odh-docs/wiki/REUSE#badges)
 [![CI](https://github.com/noi-techpark/odh-mentor-otp/actions/workflows/ci.yml/badge.svg)](https://github.com/noi-techpark/odh-mentor-otp/actions/workflows/ci.yml)
@@ -48,11 +48,9 @@ cd odh-mentor-otp
 
 #### Scripts and sub folders
 
-```docker-entrypoint.sh``` download and build data graph
-
 ```router-config.json``` define OTP updaters(GTFS-RT) and router settings from environment vars
 
-```build-config.json``` default OTP build config from environment vars
+```build-config.json``` OTP build config that includes which sources (GTFS, OSM) constitutes the graph
 
 ```south-tyrol.geojson``` the geographic extend that is extracted and processed by OTP
 
@@ -71,9 +69,7 @@ Below is a list of env variables for each container:
 
 ##### otp
 
-```JAVA_MX``` the amount of heap space available to OpenTripPlanner. (The `otp.sh` script adds `-Xmx$JAVA_MX` to the `java` command.) Default: 2G
-
-```OTP_OFFICIAL``` if *True* will use the OpenTripPlanner Official Version, otherwise the IBI-Group Version [(see Compatibility)](#compatibility)
+```JAVA_TOOL_OPTIONS``` the JVM configuration of OpenTripPlanner, for example `JAVA_TOOL_OPTIONS=-Xmx6G`.
 
 ##### build
 
@@ -150,37 +146,25 @@ Below is a list of Docker args variables for each container:
 
 Then you can start the application using the following command:
 
-#### First build Graph and Cache
+## Running OTP
 
-```bash
-docker-compose up build
+If you don't want to build the graph yourself, you can simply run the following to start OTP
+
+```
+docker run -it -p 8080:8080 ghcr.io/noi-techpark/odh-mentor-otp/odh-mentor-otp:df65ce3c8656f4431cb89d79df6b2cc1db4d7cc9
 ```
 
-#### Compatibility
+You can find the latest version of the image on its [repository page](https://github.com/noi-techpark/odh-mentor-otp/pkgs/container/odh-mentor-otp%2Fodh-mentor-otp).
 
-In OpenTripPlanner is not allowed running a graph built with a different version.
-In case you change the OpenTripPlanner version or switch from/to Ufficial/IBI-Group Version **you have to rebuild the graph**.  
+## Building a graph
 
-#### Execute OTP instance
+If you want to build graph on your local machine there are convenience scripts available that
+download the requisites and builds the graph.
 
-```bash
-docker-compose up otp
 ```
-After the graph has been built, the planner is available at port *8080*.
-
-
-#### Services
-
-defined in docker-compose.yml, both of these services are defined by the same docker image which behaves differently according to the defined environment parameters.
-
-```build``` build a new OTP graph by gtfs file in /opt/odh-mentor-otp/ directory, automatically stopped on finish, ```docker logs``` notice if the building was successful.
-
-```otp``` run a new instance of OTP by /opt/odh-mentor-otp/, distribute API rest and default UI on port 8080, need restart: "always"
-
-#### Volumes
-
-```/opt/odh-mentor-otp/:/data/``` the path used in reading and writing in which the Osm, Altimetric data are downloaded. It must contains the GTFS zip file before building the graph. Here where the graph generated will be written by OTP, in path:
-```/opt/odh-mentor-otp/openmove/Graph.obj```
+./build-graph.sh
+./run-otp.sh
+```
 
 ## Information
 

--- a/build-config.json
+++ b/build-config.json
@@ -19,5 +19,10 @@
       "timeZone": "Europe/Rome",
       "osmTagMapping": "default"
     }
+  ],
+  "dem" : [
+    {
+      "source" : "data/srtm_39_03.tif"
+    }
   ]
 }

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -4,10 +4,15 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+WGET="wget --progress=bar:force:noscroll"
+
 # OSM
 NORTH_EAST_URL=https://download.geofabrik.de/europe/italy/nord-est-latest.osm.pbf
 NORTH_EAST_PBF=data/italy-nord-est.osm.pbf
 SOUTH_TYROL_PBF=data/south-tyrol.osm.pbf
+# elevation
+ELEVATION_URL=https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/srtm_39_03.zip
+ELEVATION_ZIP=data/srtm_39_03.zip
 
 # OTP
 OTP_IMAGE=docker.io/opentripplanner/opentripplanner:2.5.0_2024-01-19T14-50
@@ -20,11 +25,17 @@ fi
 mkdir -p data
 
 if [ ! -f "${NORTH_EAST_PBF}" ]; then
-  wget --progress=bar:force:noscroll ${NORTH_EAST_URL} -O ${NORTH_EAST_PBF}
+  ${WGET} ${NORTH_EAST_URL} -O ${NORTH_EAST_PBF}
 fi
 
 # cut out South Tyrol from the large North East Italy extract
 osmium extract ${NORTH_EAST_PBF} --polygon south-tyrol.geojson -o ${SOUTH_TYROL_PBF} --overwrite
+
+if [ ! -f "${ELEVATION_ZIP}" ]; then
+  ${WGET} ${ELEVATION_URL} -O ${ELEVATION_ZIP}
+  unzip -o ${ELEVATION_ZIP} -d data
+fi
+
 
 # actually do graph build
 docker run \

--- a/docs/opentripplanner.md
+++ b/docs/opentripplanner.md
@@ -6,67 +6,41 @@ SPDX-License-Identifier: CC0-1.0
 
 # OpenTripPlanner
 
-This project is a Openmove fork of [OpenTripPlanner](http://opentripplanner.org) release:
+This project uses the regular upstream version of OpenTripPlanner with no modifications: 
+https://github.com/opentripplanner/OpenTripPlanner
 
-https://github.com/openmove/OpenTripPlanner
+@leonardehrenfried has lots of experience upstreaming code, and it's recommended to not fork OTP
+itself but send all code upstream.
 
 ## Services
 
 defined in docker-compose.yml
 
-```otp-build``` build a new OTP graph by /data directory
-
 ```otp``` run a new instance of OTP by /data
 
+## Building graphs
 
-## Scripts
+Github Actions builds fully usable container images that contain both the OTP binaries and the 
+prepared graph. These are meant for deployment to a production server.
 
-```docker-entrypoint.sh``` download and build data graph
+However, if you want to build a graph locally, you can use the following commands:
 
-```otp.sh``` a shortcut for command `java -jar otp.jar`
-
-```gtfs2bbox``` nodejs script to calculate bounding box of gtfs data and async download Openstreetmap Data
-
-
-## Download data
-
-calculate bounding box with buffer from GTFS directory
-
-```bash
-unzip -o ./data/200804_ExportGTFS.zip -d ./data/200804_ExportGTFS
+```
+./build-graph.sh
+./run-otp.sh
 ```
 
-```bash
-cd gtfs2bbox/
-npm install
-node bbox.js ../data/200804_ExportGTFS | node fetch-osm-wget.js
-```
+### Specifics
 
-**output**:
-```javascript
-{
-	stops: 4669,
-	buffer: 10,	//buffered in kilometers
-	bbox:
-	'46.01005848495291,10.000282971097848,47.32428314950289,12.86105887382695',
-	bboxfinder:
-	'http://bboxfinder.com/#46.01005848495291,10.000282971097848,47.32428314950289,12.86105887382695'
-}
-```
+OTP takes the following inputs for graph building:
 
-### Experimental
+- OSM
+- GTFS
 
-async parallel download osm data, see gtfs2bbox directory
-```bash
-cd gtfs2bbox/
-node bboxes.js ../data/200804_ExportGTFS  | node fetch-osm-wget.js
-```
+As OSM data we download the entire [North East of Italy](https://download.geofabrik.de/europe/italy/nord-est.html)
+and use `osmium` to cut out South Tyrol. The exact boundaries are defined in `south-tyrol.geojson`.
 
-## First build Graph and Cache
-
-```bash
-docker-compose up build
-```
+The GTFS feeds to use are defined in `build-config.json`.
 
 ## Execute OTP instance
 
@@ -78,6 +52,6 @@ After the graph has been built, the planner is available at port *8080*.
 
 ### Environment variables
 
-**JAVA_MX**: The amount of heap space available to OpenTripPlanner. (The `otp`
-             command adds `-Xmx$JAVA_MX` to the `java` command.) Default: 4G
+To pass JVM configuration parameters, use the environment variable `JAVA_TOOL_OPTIONS`, for example
+`JAVA_TOOL_OPTIONS='-Xmx4g'`.
 

--- a/router-config.json
+++ b/router-config.json
@@ -13,6 +13,21 @@
       "type": "stop-time-updater",
       "url": "https://mobility.api.opendatahub.testingmachine.eu/v2/GTFS-RT",
       "feedId": "sta"
+    },
+    {
+      "type" : "vehicle-rental",
+      "sourceType" : "gbfs",
+      "url" : "https://gbfs.otp.opendatahub.com/bz/2.1/gbfs.json"
+    },
+    {
+      "type" : "vehicle-rental",
+      "sourceType" : "gbfs",
+      "url" : "https://gbfs.otp.opendatahub.com/me/2.1/gbfs.json"
+    },
+    {
+      "type" : "vehicle-rental",
+      "sourceType" : "gbfs",
+      "url" : "https://gbfs.otp.opendatahub.com/papin/2.1/gbfs.json"
     }
   ]
 }


### PR DESCRIPTION
This PR updates the documentation about how OTP is built and deployed. I've tried to be careful about not removing useful information and only remove those things that I'm certain are no longer up-to-date.

It also adds elevation data to the OTP graph.