### PR TITLE
Add GBFS carsharing feed

### DIFF
--- a/router-config.json
+++ b/router-config.json
@@ -28,6 +28,11 @@
       "type" : "vehicle-rental",
       "sourceType" : "gbfs",
       "url" : "https://gbfs.otp.opendatahub.com/papin/2.1/gbfs.json"
+    },
+    {
+      "type" : "vehicle-rental",
+      "sourceType" : "gbfs",
+      "url" : "https://leonard.io/gbfs/noi/gbfs.json"
     }
   ]
 }


### PR DESCRIPTION
This adds the converted GBFS carsharing feed to OTP.

Right now this feed is totally static and we need to automate the generation of it. I suggest that we talk about it in our meeting on Friday. I also have a few question about the source feed.

The source code of the conversion is available here: https://github.com/mobidata-bw/x2gbfs/pull/79