### PR TITLE
Add caching to OTP build process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create .env file
         uses: noi-techpark/github-actions/env-file@v2
@@ -103,6 +103,14 @@ jobs:
 
       - name: use mobility.api.opendatahub.testingmachine.eu for testing
         run: sed -i 's/mobility.api.opendatahub.com/mobility.api.opendatahub.testingmachine.eu/' */config.yml
+
+      - name: Cache OSM and elevation data
+        uses: actions/cache@v4
+        with:
+          path: |
+            data/italy-nord-est.osm.pbf
+            data/srtm*
+          key: input-data
 
       - name: Build graph
         run: sh build-graph.sh 

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -19,13 +19,16 @@ OTP_IMAGE=docker.io/opentripplanner/opentripplanner:2.5.0_2024-01-19T14-50
 
 # when on github actions then install the required tools
 if [ -n "${CI+isset}" ]; then
-  sudo apt-get -qq install osmium-tool wget
+  sudo apt-get -qq install osmium-tool pyosmium wget
 fi
 
 mkdir -p data
 
 if [ ! -f "${NORTH_EAST_PBF}" ]; then
   ${WGET} ${NORTH_EAST_URL} -O ${NORTH_EAST_PBF}
+else
+  echo "Checking for updates for existing OSM file"
+  pyosmium-up-to-date ${NORTH_EAST_PBF}
 fi
 
 # cut out South Tyrol from the large North East Italy extract


### PR DESCRIPTION
I noticed that the nightly update process is slower than it needs to be and can be sped up by caching some of the input data.

In this PR I use Github Action to cache the large OSM and the elevation data download. This both speeds up the build as well as causing less stress on the upstream systems (Geofabrik, cgiar.org) that are donating their bandwidth to the world.