### PR TITLE
Fix caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,8 @@ jobs:
           path: |
             data/italy-nord-est.osm.pbf
             data/srtm*
-          key: input-data
+          key: input-data-${{ github.run_number }}
+          restore-keys: input-data
 
       - name: Build graph
         run: bash build-graph.sh


### PR DESCRIPTION
I noticed that cached OSM and elevation data are actually not put back into the cache after the OSM updates have been applied.

This config change should fix it.