### PR TITLE
Add NeTEx static parking data

### DIFF
--- a/.otp-version
+++ b/.otp-version
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
 #
 # SPDX-License-Identifier: CC0-1.0
-export OTP_IMAGE="opentripplanner/opentripplanner:2.6.0_2024-04-10T12-37"
+export OTP_IMAGE="opentripplanner/opentripplanner:2.6.0_2024-08-01T06-53"

--- a/build-config.json
+++ b/build-config.json
@@ -1,6 +1,7 @@
 {
   "embedRouterConfig": true,
   "areaVisibility": true,
+  "staticParkAndRide": false,
   "transitFeeds": [
     {
       "source": "https://gtfs.api.opendatahub.com/v1/dataset/sta-time-tables/raw",

--- a/build-config.json
+++ b/build-config.json
@@ -17,6 +17,12 @@
       "source": "https://amarillo.otp.opendatahub.testingmachine.eu/gtfs/amarillo.altoadige.gtfs.zip",
       "type": "gtfs",
       "feedId": "amarillo"
+    },
+    {
+      "source": "data/parking-netex.zip",
+      "type": "netex",
+      "feedId": "parking",
+      "ignoreParking": false
     }
   ],
   "osm": [

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -45,4 +45,4 @@ docker run \
   -v .:/var/opentripplanner/:z \
   --rm \
   -e JAVA_TOOL_OPTIONS="-Xmx6G" \
-  ${OTP_IMAGE} --build --save
+  "${OTP_IMAGE}" --abortOnUnknownConfig --build --save

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -15,10 +15,14 @@ SOUTH_TYROL_PBF=data/south-tyrol.osm.pbf
 # elevation
 ELEVATION_URL=https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/srtm_39_03.zip
 ELEVATION_ZIP=data/srtm_39_03.zip
+# parking
+PARKING_NETEX_URL=https://transmodel.api.opendatahub.com/netex/parking
+PARKING_NETEX_XML=data/shared-data.xml
+PARKING_NETEX_ZIP=data/parking-netex.zip
 
 # when on github actions then install the required tools
 if [ -n "${CI+isset}" ]; then
-  sudo apt-get -qq install osmium-tool pyosmium wget
+  sudo apt-get -qq install osmium-tool pyosmium wget zip
 fi
 
 mkdir -p data
@@ -38,6 +42,12 @@ if [ ! -f "${ELEVATION_ZIP}" ]; then
   ${WGET} ${ELEVATION_URL} -O ${ELEVATION_ZIP}
   unzip -o ${ELEVATION_ZIP} -d data
 fi
+
+# download parking data and put it into a zip
+rm -f ${PARKING_NETEX_XML} ${PARKING_NETEX_ZIP}
+wget ${PARKING_NETEX_URL} -O ${PARKING_NETEX_XML}
+
+zip --junk-paths ${PARKING_NETEX_ZIP} ${PARKING_NETEX_XML}
 
 
 # actually do graph build

--- a/infrastructure/docker/otp/Dockerfile
+++ b/infrastructure/docker/otp/Dockerfile
@@ -1,5 +1,5 @@
 # Simon, do you know how we could use the value from .otp-version here?
-FROM opentripplanner/opentripplanner:2.6.0_2024-04-10T12-37
+FROM opentripplanner/opentripplanner:2.6.0_2024-08-01T06-53
 
 WORKDIR /var/otp
 

--- a/router-config.json
+++ b/router-config.json
@@ -38,12 +38,6 @@
       "type": "stop-time-updater",
       "url": "https://amarillo.otp.opendatahub.testingmachine.eu/gtfs/amarillo.altoadige.gtfsrt.pbf",
       "feedId": "amarillo"
-    },
-    {
-      "type" : "vehicle-parking",
-      "feedId" : "noi",
-      "sourceType" : "noi-open-data-hub",
-      "url" : "https://parking.otp.opendatahub.com/parking/all.json"
     }
   ]
 }


### PR DESCRIPTION
This adds the static parking data import from the NeTEx data which I recently contributed upstream.

The nice thing about this is that NeTEx data is already being published for the NAP and we are consuming the same data source. Using the data that you're publishing is an essential part of keeping the data quality high.

cc @dulvui @rcavaliere 