### PR TITLE
Add vector tile configuration, graph build improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,10 +112,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            data/italy-nord-est.osm.pbf
             data/srtm*
-          key: input-data-${{ github.run_number }}
-          restore-keys: input-data
+          key: elevation
 
       - name: Build graph
         run: bash build-graph.sh

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,13 @@
+name: Build graph
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - run: ./build-graph.sh

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -45,7 +45,7 @@ fi
 
 # download parking data and put it into a zip
 rm -f ${PARKING_NETEX_XML} ${PARKING_NETEX_ZIP}
-wget ${PARKING_NETEX_URL} -O ${PARKING_NETEX_XML}
+${WGET} ${PARKING_NETEX_URL} -O ${PARKING_NETEX_XML}
 
 zip --junk-paths ${PARKING_NETEX_ZIP} ${PARKING_NETEX_XML}
 

--- a/infrastructure/docker/otp/Dockerfile
+++ b/infrastructure/docker/otp/Dockerfile
@@ -3,7 +3,7 @@ FROM opentripplanner/opentripplanner:2.6.0_2024-08-01T06-53
 
 WORKDIR /var/otp
 
-ADD router-config.json /var/otp/
+ADD router-config.json otp-config.json /var/otp/
 ADD graph.obj /var/otp/
 
 ENTRYPOINT java $JAVA_OPTS -cp @/app/jib-classpath-file @/app/jib-main-class-file /var/otp/ --load --serve

--- a/otp-config.json
+++ b/otp-config.json
@@ -1,0 +1,5 @@
+{
+  "otpFeatures": {
+    "SandboxAPIMapboxVectorTilesApi": true
+  }
+}

--- a/router-config.json
+++ b/router-config.json
@@ -8,6 +8,74 @@
       "maxWindow": "16h"
     }
   },
+  "vectorTiles": {
+    "layers": [
+      {
+        "name": "stops",
+        "type": "Stop",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 14,
+        "cacheMaxSeconds": 600
+      },
+      // flex zones
+      {
+        "name": "areaStops",
+        "type": "AreaStop",
+        "mapper": "OTPRR",
+        "maxZoom": 20,
+        "minZoom": 14,
+        "cacheMaxSeconds": 600
+      },
+      {
+        "name": "stations",
+        "type": "Station",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 12,
+        "cacheMaxSeconds": 600
+      },
+      // all rental places: stations and free-floating vehicles
+      {
+        "name": "citybikes",
+        "type": "VehicleRental",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 14,
+        "cacheMaxSeconds": 60,
+        "expansionFactor": 0.25
+      },
+      // just free-floating vehicles
+      {
+        "name": "rentalVehicles",
+        "type": "VehicleRentalVehicle",
+        "mapper": "DigitransitRealtime",
+        "maxZoom": 20,
+        "minZoom": 14,
+        "cacheMaxSeconds": 60
+      },
+      // just rental stations
+      {
+        "name": "rentalStations",
+        "type": "VehicleRentalStation",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 14,
+        "cacheMaxSeconds": 600
+      },
+      // no real-time, translatable fields are translated based on accept-language header
+      // and contains less fields than the Stadtnavi mapper
+      {
+        "name": "vehicleParking",
+        "type": "VehicleParking",
+        "mapper": "Digitransit",
+        "maxZoom": 20,
+        "minZoom": 14,
+        "cacheMaxSeconds": 600,
+        "expansionFactor": 0.25
+      }
+    ]
+  },
   "updaters": [
     {
       "type": "stop-time-updater",


### PR DESCRIPTION
This makes the following changes:

- it enables the vector tiles API as requested by @slvlirnoff
- adds a workflow for running the graph build during a PR
- doesn't cache the OSM data download anymore since it would never update the cache. to fix that I will open a separate one.

cc @dulvui 