### PR TITLE
Activate error handling for graph build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,8 @@ jobs:
           key: osm-${{ env.OSM_CACHE_VERSION }}
 
       - name: Build graph
-        run: bash build-graph.sh
+        # the script uses error handling with +e, so please don't run it with bash prepended in this line
+        run: ./build-graph.sh
 
       - name: Build and push
         if: github.repository_owner == 'noi-techpark'


### PR DESCRIPTION
The script actually has error handling but it's skipped when it's run with `bash build-graph.sh`.

This makes the build fail when the NeTex file cannot be downloaded, which is what we want (rather than silently continuing).

@dulvui 