### PR TITLE
Use newest NeTEx feed, upgrade OTP

### DIFF
--- a/.otp-version
+++ b/.otp-version
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
 #
 # SPDX-License-Identifier: CC0-1.0
-export OTP_IMAGE="opentripplanner/opentripplanner:2.6.0_2024-09-05T13-13"
+export OTP_IMAGE="opentripplanner/opentripplanner:2.7.0_2024-11-19T11-28"

--- a/build-config.json
+++ b/build-config.json
@@ -16,11 +16,11 @@
       "type": "gtfs",
       "feedId": "skyalps"
     },
-    {
+    /*{
       "source": "https://amarillo.otp.opendatahub.testingmachine.eu/gtfs/amarillo.altoadige.gtfs.zip",
       "type": "gtfs",
       "feedId": "amarillo"
-    },
+    },*/
     {
       "source": "data/parking-netex.xml.zip",
       "type": "netex",

--- a/build-config.json
+++ b/build-config.json
@@ -5,7 +5,6 @@
   "transitModelTimeZone": "Europe/Rome",
   "transitFeeds": [
     {
-      // we rehost the NeTEx file because the original FTP server has issues
       "source": "data/sta-netex.xml.zip",
       "type": "netex",
       "feedId": "sta",

--- a/build-config.json
+++ b/build-config.json
@@ -6,7 +6,7 @@
   "transitFeeds": [
     {
       // we rehost the NeTEx file because the original FTP server has issues
-      "source": "https://leonard.io/otp/alto-adige-netex-epip.xml.zip",
+      "source": "data/sta-netex.xml.zip",
       "type": "netex",
       "feedId": "sta",
       "groupFilePattern": "(.*)\\.xml"

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -13,7 +13,9 @@ NORTH_EAST_URL=https://download.geofabrik.de/europe/italy/nord-est-latest.osm.pb
 NORTH_EAST_PBF=data/italy-nord-est.osm.pbf
 SOUTH_TYROL_PBF=data/south-tyrol.osm.pbf
 # elevation
-ELEVATION_URL=https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/srtm_39_03.zip
+# this URL is way too overloaded, so we mirror it
+# ELEVATION_URL=https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/srtm_39_03.zip
+ELEVATION_URL=https://leonard.io/srtm/srtm_39_03.zip
 ELEVATION_ZIP=data/srtm_39_03.zip
 # transit data
 TRANSIT_NETEX_URL="https://rapuser:rappass@web01.sta.bz.it/netex/api/v4/downloadVersion?level=4&agencyCode=IT-ITH1"

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -16,8 +16,10 @@ SOUTH_TYROL_PBF=data/south-tyrol.osm.pbf
 ELEVATION_URL=https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/srtm_39_03.zip
 ELEVATION_ZIP=data/srtm_39_03.zip
 # transit data
-TRANSIT_NETEX_URL="ftp://ftp01.sta.bz.it/netex/$(date +%Y)/plan/EU_Profil/NX-PI_01_it_apb_LINE_apb__$(date +%Y%m%d).xml.zip"
-TRANSIT_NETEX_ZIP=data/sta-netex.xml.zip
+TRANSIT_NETEX_URL="https://rapuser:rappass@web01.sta.bz.it/netex/api/v4/downloadVersion?level=4&agencyCode=IT-ITH1"
+TRANSIT_NETEX_XML=data/sta-netex.xml
+TRANSIT_NETEX_GZ=${TRANSIT_NETEX_XML}.gz
+TRANSIT_NETEX_ZIP=${TRANSIT_NETEX_XML}.zip
 # parking
 PARKING_NETEX_URL=https://transmodel.api.opendatahub.com/netex/parking
 PARKING_NETEX_XML=data/shared-data.xml
@@ -47,8 +49,11 @@ if [ ! -f "${ELEVATION_ZIP}" ]; then
   unzip -o ${ELEVATION_ZIP} -d data
 fi
 
-#echo "Downloading NeTEx transit data from ${TRANSIT_NETEX_URL}"
-#${CURL} "${TRANSIT_NETEX_URL}" -o ${TRANSIT_NETEX_ZIP}
+rm -f ${TRANSIT_NETEX_ZIP}
+echo "Downloading NeTEx transit data from ${TRANSIT_NETEX_URL}"
+${CURL} "${TRANSIT_NETEX_URL}" -o ${TRANSIT_NETEX_GZ}
+gunzip --force ${TRANSIT_NETEX_GZ}
+zip ${TRANSIT_NETEX_ZIP} ${TRANSIT_NETEX_XML}
 
 # download parking data and put it into a zip
 rm -f ${PARKING_NETEX_XML} ${PARKING_NETEX_ZIP}

--- a/infrastructure/docker/otp/Dockerfile
+++ b/infrastructure/docker/otp/Dockerfile
@@ -1,5 +1,5 @@
 # Simon, do you know how we could use the value from .otp-version here?
-FROM opentripplanner/opentripplanner:2.6.0_2024-09-05T13-13
+FROM opentripplanner/opentripplanner:2.7.0_2024-11-19T11-28
 
 WORKDIR /var/otp
 


### PR DESCRIPTION
This PR does the following:

- it enables the new NeTEx feed that was provided by STA
- upgrades to the latest version of OTP
- it removes the Amarillo GTFS file from the build Amarillo is down

cc @rcavaliere 

@clezag Do you know anything about Amadillo?