### PR TITLE
Use compact headers for build process

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-OTP_IMAGE="lehrenfried/opentripplanner:swiss-epip"
+OTP_IMAGE="opentripplanner/opentripplanner:2.10.0_2026-04-27T13-58"
 
 CARSHARING_BASEURL=http://localhost:8091
 AMARILLO_BASEURL=http://localhost:9095

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ env:
   DOCKER_IMAGE_CARSHARING: ghcr.io/${{ github.repository }}/odh-mentor-otp-carsharing
   DOCKER_IMAGE_ECHARGING: ghcr.io/${{ github.repository }}/odh-mentor-otp-echarging
   DOCKER_IMAGE_AMARILLO: ghcr.io/${{ github.repository }}/odh-mentor-otp-amarillo
-  OTP_IMAGE: "lehrenfried/opentripplanner:swiss-epip"
+  OTP_IMAGE: "opentripplanner/opentripplanner:2.10.0_2026-04-27T13-58"
 
 jobs:
   deploy-test:

--- a/build-graph.sh
+++ b/build-graph.sh
@@ -95,7 +95,7 @@ docker run \
   --restart no \
   -v "${VOLUME_MOUNT}:/var/opentripplanner/:z" \
   --rm \
-  -e JAVA_TOOL_OPTIONS="-Xmx40G -XX:+UseContainerSupport" \
+  -e JAVA_TOOL_OPTIONS="-Xmx40G -XX:+UseContainerSupport -XX:+UseCompactObjectHeaders" \
   "${OTP_IMAGE}" --abortOnUnknownConfig --build --save
 
 


### PR DESCRIPTION
This relatively new feature (Java 25) saves about 10-20% of memory.

Also, all of my changes have been merged upstream, so we can use the official Docker image.