### PR TITLE
Resolve Mentz line versions in STA feed, fix SSPs

### DIFF
--- a/build-sta-netex.sh
+++ b/build-sta-netex.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+set -euo pipefail
+
+CURL="curl --location --fail --show-error -#"
+
+today=$(date +"%Y%m%d")
+STA_NETEX_URL="ftp://ftp.sta.bz.it/netex/2026/plan/EU_profil/NX-PI_01_it_apb_LINE_apb__${today}.xml.zip"
+
+INPUT_FILE=sta.netex.zip
+OUTPUT_FILE=sta.epip.netex.xml
+OUTPUT_ZIP_FILE=${OUTPUT_ZIP_FILE:-sta.epip.netex.zip}
+
+INTERMEDIATE_DB=sta.lmdb
+EPIP_DB=sta-epip.lmdb
+
+if [ ! -d "badger" ]; then
+  git clone --branch mentz-line-versions https://github.com/leonardehrenfried/badger.git
+fi
+
+cd badger
+
+uv sync
+UV_VENV_CLEAR=1 bash scripts/setup.sh
+
+source .venv/bin/activate
+
+echo "clean up previous build"
+rm -Rf ./sta*
+
+
+${CURL} ${STA_NETEX_URL} -o ${INPUT_FILE}
+echo "Starting to rewrite STA NeTEx data (resolving line versions, rewriting SSP IDs)"
+
+uv run python -m conv.netex_to_db ${INPUT_FILE} ${INTERMEDIATE_DB}
+uv run python -m fix.resolve_mentz_line_versions ${INTERMEDIATE_DB}
+uv run python -m fix.rewrite_sta_ssp_ids ${INTERMEDIATE_DB}
+uv run python -m conv.epip_db_to_db ${INTERMEDIATE_DB} ${EPIP_DB}
+uv run python -m conv.epip_db_to_xml ${EPIP_DB} ${OUTPUT_FILE}
+
+zip ${OUTPUT_ZIP_FILE} ${OUTPUT_FILE} --junk-paths

--- a/build-switzerland-netex.sh
+++ b/build-switzerland-netex.sh
@@ -13,7 +13,7 @@ OUTPUT_FILE=switzerland.epip.netex.xml
 OUTPUT_ZIP_FILE=${OUTPUT_ZIP_FILE:-switzerland.epip.netex.zip}
 
 if [ ! -d "badger" ]; then
-  git clone --branch binary_relation_serializer https://github.com/MMTIS/badger.git
+  git clone --branch mentz-line-versions https://github.com/leonardehrenfried/badger.git
 fi
 
 cd badger


### PR DESCRIPTION
This PR contains a script to rewrite the current STA NeTEx feed to apply the Mentz line versions to the operating periods. It also fixes the ids of the ScheduledStopPoints.

Right now, it only builds the feed but doesn't integrate it into the OTP build. I would like to run the script first before doing that.

CAUTION: It reuses the same badger folder than the Swiss transformation one. You must delete the current folder and let it re-initialize.

### Result

The good news is that planning a trip in the future is now possible with this change.

The bad news is that the SIRI match rate is a bit lower. It went from 50% to about 40%. This means that there is likely a problem when resolving the versions for each day. It will need further investigation. I'm on it.

Nevertheless, you can see real-time update in the frontend:

<img width="740" height="521" alt="image" src="https://github.com/user-attachments/assets/55f69ba6-93c1-44ef-9b49-be413d48deb7" />


### Cron

@clezag Can you take over running this every night? If this works, then we can use it in OTP.

cc @rcavaliere @flaktack 
