### PR TITLE
Switch pull with fetch

### DIFF
--- a/build-sta-netex.sh
+++ b/build-sta-netex.sh
@@ -23,7 +23,7 @@ if [ ! -d "badger" ]; then
 fi
 
 cd badger
-git pull
+git fetch
 # version that implements the corrected line resolution algorithm
 git checkout 7c8bc5909f851b695ab4f9285d1fd6f7edd9b297
 


### PR DESCRIPTION
Seems that `git pull` throws an error if you don't specify where exactly it should pull.

https://otp-graph-build.opendatahub.testingmachine.eu/log/netex.sta.20260526_020001.log