### PR TITLE
OTP: save the graph build report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ data
 **node_modules
 
 graph.obj
+report
 
 *.xml
 *.zip

--- a/build-config.json
+++ b/build-config.json
@@ -1,4 +1,5 @@
 {
+  "dataImportReport": true,
   "embedRouterConfig": true,
   "areaVisibility": true,
   "staticParkAndRide": false,


### PR DESCRIPTION
This would allow investigating build issues after the graph is built ([`dataImportReport`](https://docs.opentripplanner.org/en/latest/BuildConfiguration/#dataImportReport))

If all goes well the report should be present here:
https://otp-graph-build.opendatahub.testingmachine.eu/