### PR TITLE
import Swiss accommodation POI from discoverswiss source

### DIFF
--- a/pelias/README.md
+++ b/pelias/README.md
@@ -14,7 +14,7 @@ Please refer to the instructions at <https://github.com/pelias/docker> in order 
 
 The minimum configuration required in order to run this project are [installing prerequisites](https://github.com/pelias/docker#prerequisites), [install the pelias command](https://github.com/pelias/docker#installing-the-pelias-command) and [configure the environment](https://github.com/pelias/docker#configure-environment)
 
-You also need `curl`, `jq` and `node` to import OpenTripPlanner stops and NOI Datahub Activities and Accomodations POI.
+You also need `curl`, `jq` and `node` to import OpenTripPlanner stops, NOI Datahub Activities and Accomodations POI, and Swiss accommodation POI from the Open Data Hub `discoverswiss` source.
 
 Please ensure that's all working fine before continuing.
 

--- a/pelias/importers/delete_old_poi_and_stops.sh
+++ b/pelias/importers/delete_old_poi_and_stops.sh
@@ -37,7 +37,19 @@ function delete_old_accomodation {
   }
   '
 }
+function delete_old_discoverswiss_accomodation {
+  curl -X POST "${ELASTICSEARCH_HOST}:9200/pelias/_delete_by_query?pretty" -H 'Content-Type: application/json' -d'
+  {
+    "query": {
+      "match": {
+        "source": "discoverswiss-accomodation"
+      }
+    }
+  }
+  '
+}
 
 delete_old_stops
 delete_old_poi
 delete_old_accomodation
+delete_old_discoverswiss_accomodation

--- a/pelias/importers/download_and_prepare_poi.sh
+++ b/pelias/importers/download_and_prepare_poi.sh
@@ -9,11 +9,14 @@ curl "https://tourism.api.opendatahub.com/v1/Accommodation?pagesize=20000" > ./d
 curl "https://tourism.api.opendatahub.com/v1/STA/Accommodation?language=en&referer=SuedtirolMobilWeb&fields=Id%2CAccoDetail.en.Name%2CAccoDetail.en.City&pagesize=10000" > ./data/csv-importer/accomodation-poi-filtered-set.json
 
 node ./importers/process-touristic-poi.js
+node ./importers/fetch-discoverswiss-accomodation.js
 
 TOURISTIC_CSV=./data/csv-importer/touristic-poi.csv
 TOURISTIC_JSON_FILE=./data/csv-importer/touristic-poi.json
 ACCOMODATION_CSV=./data/csv-importer/accomodation-poi.csv
 ACCOMODATION_JSON_FILE=./data/csv-importer/accomodation-poi.json
+DISCOVERSWISS_ACCOMODATION_CSV=./data/csv-importer/discoverswiss-accomodation-poi.csv
+DISCOVERSWISS_ACCOMODATION_JSON_FILE=./data/csv-importer/discoverswiss-accomodation-poi.json
 
 # transform JSON data to CSV with jq
 echo "source,layer,id,lat,lon,name,name_de,name_en,name_fr,name_it,category_json,addendum_json_poi" > $TOURISTIC_CSV
@@ -35,3 +38,13 @@ cat $ACCOMODATION_JSON_FILE | jq --raw-output ".[] | [
     ([(.AccoType,.AccoCategory) | \"accomodation:\"+ (.Id | gsub(\" \"; \"_\"))] | tostring), \
     (.|tostring) \
     ] | @csv" >> $ACCOMODATION_CSV;
+
+echo "source,layer,id,lat,lon,name,name_de,name_en,name_fr,name_it,category_json,addendum_json_accomodation" > $DISCOVERSWISS_ACCOMODATION_CSV
+cat $DISCOVERSWISS_ACCOMODATION_JSON_FILE | jq --raw-output ".[] | [
+    \"discoverswiss-accomodation\",\"venue\",\
+    .Id,\
+    .Latitude,.Longitude,\
+    .AccoDetail.it.Name,.AccoDetail.de.Name,.AccoDetail.en.Name,.AccoDetail.fr.Name,.AccoDetail.it.Name,\
+    ([(.AccoType,.AccoCategory) | \"accomodation:\"+ (.Id | gsub(\" \"; \"_\"))] | tostring), \
+    (.|tostring) \
+    ] | @csv" >> $DISCOVERSWISS_ACCOMODATION_CSV;

--- a/pelias/importers/fetch-discoverswiss-accomodation.js
+++ b/pelias/importers/fetch-discoverswiss-accomodation.js
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 routeRANK <info@routerank.com>
+//
+// SPDX-License-Identifier: MIT
+
+let fs = require('fs');
+
+const DATA_DIR = __dirname + "/../data/csv-importer";
+const EXPORT_FILE = DATA_DIR + "/discoverswiss-accomodation-poi.json";
+
+const ODH_API_URL = process.env.ODH_API_URL || 'https://tourism.api.opendatahub.com';
+const PAGESIZE = process.env.DISCOVERSWISS_PAGESIZE || 1000;
+
+if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR);
+}
+
+async function fetchAllPages() {
+    let items = [];
+    let page = 1;
+    let totalPages = 1;
+
+    while (page <= totalPages) {
+        let url = `${ODH_API_URL}/v1/Accommodation?source=discoverswiss&pagesize=${PAGESIZE}&pagenumber=${page}`;
+        console.log(`Fetching page ${page}/${totalPages}: ${url}`);
+        let response = await fetch(url).then((res) => res.json());
+        totalPages = response.TotalPages;
+        items = items.concat(response.Items);
+        page++;
+    }
+
+    return items;
+}
+
+fetchAllPages().then((items) => {
+    fs.writeFileSync(EXPORT_FILE, JSON.stringify(items, null, 2));
+    console.log(`Wrote ${items.length} discoverswiss accommodation records to ${EXPORT_FILE}`);
+});

--- a/pelias/pelias.json
+++ b/pelias/pelias.json
@@ -47,7 +47,7 @@
     },
     "csv": {
       "datapath": "/data/csv-importer",
-      "files": ["stops.csv", "accomodation-poi.csv", "touristic-poi.csv"],
+      "files": ["stops.csv", "accomodation-poi.csv", "touristic-poi.csv", "discoverswiss-accomodation-poi.csv"],
       "download": [
       ]
     },


### PR DESCRIPTION
#293 

## Summary
- Import Swiss accommodation POI into the Pelias geocoder from Open Data Hub's `source=discoverswiss` endpoint (~5500 records)
- New paginated fetch script (`fetch-discoverswiss-accomodation.js`), tagged under its own `discoverswiss-accomodation` source so it can be refreshed/deleted independently of the existing accommodation import
- Wired into the existing CSV import pipeline (`pelias.json`, `download_and_prepare_poi.sh`, `delete_old_poi_and_stops.sh`)